### PR TITLE
Fix various spelling mistakes in source and ideas.md

### DIFF
--- a/other/ideas.md
+++ b/other/ideas.md
@@ -148,7 +148,7 @@ Note that because we will only override `read`/`write` or `recv`/`send` (only
 one of these two pairs), the other will remain for exclusive communication over
 the domain socket.
 
-One idea would actually be to allocate two shared memory segements, one for each
+One idea would actually be to allocate two shared memory segments, one for each
 channel. Then we could set the file permissions on server/client side such that
 each side could only read or write to the buffers it is allowed to.
 

--- a/source/domain/client.c
+++ b/source/domain/client.c
@@ -41,7 +41,7 @@ void setup_socket(int connection, int busy_waiting) {
 	// It only has two members:
 	// 1. sun_family: The family of the socket. Should be AF_UNIX
 	//                for UNIX-domain sockets.
-	// 2. sun_path: Noting that a UNIX-domain socket ist just a
+	// 2. sun_path: Noting that a UNIX-domain socket is just a
 	//              file in the file-system, it also has a path.
 	//              This may be any path the program has permission
 	//              to create, read and write files in. The maximum
@@ -112,7 +112,7 @@ int create_connection(int busy_waiting) {
 
 int main(int argc, char* argv[]) {
 	// File descriptor for the socket over which
-	// the communciation will happen with the client
+	// the communication will happen with the client
 	int connection;
 
 	// Flag to determine whether or not to

--- a/source/domain/server.c
+++ b/source/domain/server.c
@@ -54,7 +54,7 @@ void setup_socket(int socket_descriptor) {
 	// 1. sun_family: The family of the socket. Should be AF_UNIX
 	//                for UNIX-domain sockets (AF_LOCAL is the same,
 	//                but AF_UNIX is POSIX).
-	// 2. sun_path: Noting that a UNIX-domain socket ist just a
+	// 2. sun_path: Noting that a UNIX-domain socket is just a
 	//              file in the file-system, it also has a path.
 	//              This may be any path the program has permission
 	//              to create, read and write files in. The maximum
@@ -157,7 +157,7 @@ int main(int argc, char* argv[]) {
 	// File descriptor for the server socket
 	int socket_descriptor;
 	// File descriptor for the socket over which
-	// the communciation will happen with the client
+	// the communication will happen with the client
 	int connection;
 
 	// Flag to determine if we want busy-waiting

--- a/source/eventfd/eventfd-bi.c
+++ b/source/eventfd/eventfd-bi.c
@@ -71,7 +71,7 @@ void server_communicate(int descriptor, struct Arguments* args) {
 }
 
 void communicate(int descriptor, struct Arguments* args) {
-	// File descriptors can only be shared bewteen related processes,
+	// File descriptors can only be shared between related processes,
 	// therefore we will need to fork this process
 	pid_t pid;
 

--- a/source/eventfd/eventfd-uni.c
+++ b/source/eventfd/eventfd-uni.c
@@ -51,7 +51,7 @@ void server_communicate(int descriptor, struct Arguments* args) {
 }
 
 void communicate(int descriptor, struct Arguments* args) {
-	// File descriptors can only be shared bewteen related processes,
+	// File descriptors can only be shared between related processes,
 	// therefore we will need to fork this process
 	pid_t pid;
 

--- a/source/mmap/client.c
+++ b/source/mmap/client.c
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
 				 Without MAP_SHARED, writes may be buffered by the OS.
 			 * MAP_FILE: the default (zero) flag.
 		5: The file descriptor to the opened file.
-		6: The offset from the beginnning in the file, starting from which to map.
+		6: The offset from the beginning in the file, starting from which to map.
 	*/
 	// clang-format off
   file_memory = mmap(
@@ -118,7 +118,7 @@ int main(int argc, char* argv[]) {
 	communicate(file_memory, &args);
 
 	// Unmap the file from the process memory
-	// Actually unncessary because the OS will do
+	// Actually unnecessary because the OS will do
 	// this automatically when the process terminates
 	if (munmap(file_memory, args.size) < 0) {
 		throw("Error unmapping file!");

--- a/source/mmap/server.c
+++ b/source/mmap/server.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
 				 Without MAP_SHARED, writes may be buffered by the OS.
 			 * MAP_FILE: the default (zero) flag.
 		5: The file descriptor to the opened file.
-		6: The offset from the beginnning in the file, starting from which to map.
+		6: The offset from the beginning in the file, starting from which to map.
 	*/
 	// clang-format off
   file_memory = mmap(
@@ -135,7 +135,7 @@ int main(int argc, char *argv[]) {
 	communicate(file_memory, &args);
 
 	// Unmap the file from the process memory
-	// Actually unncessary because the OS will do
+	// Actually unnecessary because the OS will do
 	// this automatically when the process terminates
 	if (munmap(file_memory, args.size) < 0) {
 		throw("Error unmapping file!");

--- a/source/other/semaphore-client.c
+++ b/source/other/semaphore-client.c
@@ -39,7 +39,7 @@ int semaphore_operation(int semaphore_id, int action) {
 	// Modify the value somehow
 	operations[0].sem_op = action;
 	// When the process exits, have the OS undo
-	// the value change of the semphore
+	// the value change of the semaphore
 	// Can also set IPC_NOWAIT, so that the semaphore
 	// will never block, but fail the wait operation
 	// when the semaphore value is 0

--- a/source/tcp/other/server.c
+++ b/source/tcp/other/server.c
@@ -27,7 +27,7 @@ void *get_in_addr(struct sockaddr *sa) {
 	if (sa->sa_family == AF_INET) {
 		// Cast the raw address protocol part in sockaddr
 		// to the more accessible sockaddr_in structure
-		// so we can aaccess the s_addr field
+		// so we can access the s_addr field
 		struct sockaddr_in *in = (struct sockaddr_in *)sa;
 		return &(in->sin_addr);
 	} else {
@@ -133,7 +133,7 @@ int main(int argc, const char *argv[]) {
 		exit(1);
 	}
 
-	printf("Server: Wainting for connections ...");
+	printf("Server: Waiting for connections ...");
 
 	while (true) {
 		sin_size = sizeof their_addr;
@@ -152,7 +152,7 @@ int main(int argc, const char *argv[]) {
 							get_in_addr((struct sockaddr *)&their_addr),
 							ip,
 							sizeof ip);
-		printf("Server: Conneted to: %s\n", ip);
+		printf("Server: Connected to: %s\n", ip);
 
 		// Fork the process at this point
 		if (fork() == 0) {

--- a/source/tcp/server.c
+++ b/source/tcp/server.c
@@ -190,7 +190,7 @@ void communicate(int descriptor, struct Arguments *args, int busy_waiting) {
 
 		// Read from client
 		if (receive(descriptor, buffer, args->size, busy_waiting) == -1) {
-			throw("Error receving from server");
+			throw("Error receiving from server");
 		}
 
 		benchmark(&bench);


### PR DESCRIPTION
There are some spelling mistakes in comments and literal strings as well as in ideas.md as found using codespell. Fix these.